### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills using GitHub, part of the GitHub Certifications program",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
Adds the missing "GitHub Skills" activity to the school activities signup page.

## Changes
- Added new activity "GitHub Skills" to the activities dictionary in `src/app.py`
- Description: Learn practical coding and collaboration skills using GitHub, part of the GitHub Certifications program
- Schedule: Mondays and Wednesdays, 3:30 PM - 4:30 PM
- Max participants: 25

## Closes
Fixes #6 

## Context
This is time-sensitive as registrations close by end of this week. The activity was announced by the principal as part of a new partnership with GitHub for the GitHub Certifications program.